### PR TITLE
Updates typescript types so that event names and signatures are specified

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,8 +5,8 @@ type AttachListener<Events extends EventsConfiguration> = <EventName extends (ke
 declare class Nanobus<Events extends EventsConfiguration> {
   private _name: string
   private _starListeners: Array<StarListener<Events>>
-  private _listeners: { [key: keyof Events]: Array<Events[keyof Events]> }
-  private _emit<EventName extends keyof Events>(listeners: Array<Events[infer EventName]>, data: Parameters<Events[EventName]>): void
+  private _listeners: { [key in keyof Events]: Array<Events[keyof Events]> }
+  private _emit<EventName extends keyof Events>(listeners: Array<Events[EventName]>, data: Parameters<Events[EventName]>): void
   private _emit<EventName extends keyof Events>(listeners: Array<StarListener<Events>>, eventName: EventName, data: Parameters<Events[EventName]>, uuid?: number)
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-type EventsConfiguration = { [eventName: string | Symbol]: (...args: any[]) => void }
+type EventsConfiguration = { [eventName: string]: (...args: any[]) => void }
 type StarListener<Events extends EventsConfiguration> = <EventName extends keyof Events>(eventName: EventName, ...args: Parameters<Events[EventName]>) => void
 type AttachListener<Events extends EventsConfiguration> = <EventName extends (keyof Events) | '*'>(eventName: EventName, listener: EventName extends '*' ? StarListener<Events> : Events[EventName]) => Nanobus<Events>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,9 +11,9 @@ declare class Nanobus<Events extends EventsConfiguration> {
 
   /**
    * Allowed events and the arguments that go with them should be specified by passing an interface in which each entry's key defines an event name, and each entry's value defines the signature for a listener for the event.
-   * 
+   *
    * For example:
-   * 
+   *
    * ```
    * const emitter = new Nanobus<{
    *   start: (options: Options) => void,
@@ -22,23 +22,23 @@ declare class Nanobus<Events extends EventsConfiguration> {
    *   result: (part1: number, part2: number) => void,
    * }>()
    * ```
-   * 
+   *
    * This will cause emissions and subscriptions to be type-checked.
-   * 
+   *
    * For example, this call would be allowed:
-   * 
+   *
    * ```
    * emitter.emit('error', new Error('something failed'))
    * ```
-   * 
+   *
    * This call would be disallowed because the event name isn't allowed:
-   * 
+   *
    * ```
    * emitter.emit('complete')
    * ```
-   * 
+   *
    * This call would be disallowed because `part2` must be a number, but isn't:
-   * 
+   *
    * ```
    * emitter.emit('result', 1, 'text')
    * ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,20 +1,61 @@
-type NanobusListener = (...args: any[]) => void
-type AttachListener = (eventName:string, listener:NanobusListener) => Nanobus
+type EventsConfiguration = { [eventName: string | Symbol]: (...args: any[]) => void }
+type StarListener<Events extends EventsConfiguration> = <EventName extends keyof Events>(eventName: EventName, ...args: Parameters<Events[EventName]>) => void
+type AttachListener<Events extends EventsConfiguration> = <EventName extends (keyof Events) | '*'>(eventName: EventName, listener: EventName extends '*' ? StarListener<Events> : Events[EventName]) => Nanobus<Events>
 
-declare class Nanobus {
-  private _name:string
-  private _startListeners:Array<any>
-  private _listeners:{[key:string]:any}
-  constructor(name?:string)
-  emit:(eventName:string, ...args:any[]) => Nanobus
-  on:AttachListener
-  addListener:AttachListener
-  prependListener:AttachListener
-  once:AttachListener
-  prependOnceListener:AttachListener
-  removeListener:AttachListener
-  removeAllListeners(eventName:string):Nanobus
-  listeners(eventName:string):NanobusListener[]
+declare class Nanobus<Events extends EventsConfiguration> {
+  private _name: string
+  private _starListeners: Array<StarListener<Events>>
+  private _listeners: { [key: keyof Events]: Array<Events[keyof Events]> }
+  private _emit<EventName extends keyof Events>(listeners: Array<Events[infer EventName]>, data: Parameters<Events[EventName]>): void
+  private _emit<EventName extends keyof Events>(listeners: Array<StarListener<Events>>, eventName: EventName, data: Parameters<Events[EventName]>, uuid?: number)
+
+  /**
+   * Allowed events and the arguments that go with them should be specified by passing an interface in which each entry's key defines an event name, and each entry's value defines the signature for a listener for the event.
+   * 
+   * For example:
+   * 
+   * ```
+   * const emitter = new Nanobus<{
+   *   start: (options: Options) => void,
+   *   message: (text: string) => void,
+   *   error: (error: Error) => void,
+   *   result: (part1: number, part2: number) => void,
+   * }>()
+   * ```
+   * 
+   * This will cause emissions and subscriptions to be type-checked.
+   * 
+   * For example, this call would be allowed:
+   * 
+   * ```
+   * emitter.emit('error', new Error('something failed'))
+   * ```
+   * 
+   * This call would be disallowed because the event name isn't allowed:
+   * 
+   * ```
+   * emitter.emit('complete')
+   * ```
+   * 
+   * This call would be disallowed because `part2` must be a number, but isn't:
+   * 
+   * ```
+   * emitter.emit('result', 1, 'text')
+   * ```
+   */
+  constructor(name?: string)
+  emit<EventName extends keyof Events>(eventName: EventName, ...args: Parameters<Events[EventName]>): this
+  on: AttachListener<Events>
+  addListener: AttachListener<Events>
+  prependListener: AttachListener<Events>
+  once: AttachListener<Events>
+  prependOnceListener: AttachListener<Events>
+  removeListener<EventName extends keyof Events, Listener extends Events[EventName]>(eventName: EventName, listener: Listener): true | void
+  removeListener(eventName: '*', listener: StarListener): true | void
+  removeAllListeners<EventName extends keyof Events>(eventName: EventName): this
+  removeAllListeners(eventName: '*'): this
+  listeners<EventName extends keyof Events>(eventName: EventName): Array<Events[EventName]>
+  listeners(eventName: '*'): Array<StarListener<Events>>
 }
 
 export = Nanobus

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,7 +51,7 @@ declare class Nanobus<Events extends EventsConfiguration> {
   once: AttachListener<Events>
   prependOnceListener: AttachListener<Events>
   removeListener<EventName extends keyof Events, Listener extends Events[EventName]>(eventName: EventName, listener: Listener): true | void
-  removeListener(eventName: '*', listener: StarListener): true | void
+  removeListener(eventName: '*', listener: StarListener<Events>): true | void
   removeAllListeners<EventName extends keyof Events>(eventName: EventName): this
   removeAllListeners(eventName: '*'): this
   listeners<EventName extends keyof Events>(eventName: EventName): Array<Events[EventName]>

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ type EventsConfiguration = { [eventName: string]: (...args: any[]) => void }
 type StarListener<Events extends EventsConfiguration> = <EventName extends keyof Events>(eventName: EventName, ...args: Parameters<Events[EventName]>) => void
 type AttachListener<Events extends EventsConfiguration> = <EventName extends (keyof Events) | '*'>(eventName: EventName, listener: EventName extends '*' ? StarListener<Events> : Events[EventName]) => Nanobus<Events>
 
-declare class Nanobus<Events extends EventsConfiguration> {
+declare class Nanobus<Events extends EventsConfiguration = EventsConfiguration> {
   private _name: string
   private _starListeners: Array<StarListener<Events>>
   private _listeners: { [key in keyof Events]: Array<Events[keyof Events]> }


### PR DESCRIPTION
This is inspired by https://github.com/andywer/typed-emitter/blob/master/index.d.ts, which implements similar typed events for Node's EventEmitter.

Also
- fixes a typo in the name "_starListeners"
- types `private _emit`
- adds a JSDoc comment to explain how to use the constructor
- fixes the return type for `removeListener`

This ensures that event names and corresponding arguments are used as defined:

![image](https://user-images.githubusercontent.com/6340825/67641905-a9fe0000-f8dc-11e9-9b3d-c6875b817fa1.png)

It also allows the Typescript language server to provide autocomplete suggestions, which is pretty helpful:

![image](https://user-images.githubusercontent.com/6340825/67641924-dade3500-f8dc-11e9-92a8-db87304f064d.png)

